### PR TITLE
Fix typo in dragon description JSON

### DIFF
--- a/samples/00_textgeneration/sample_0003_dragon_description/000_init.json
+++ b/samples/00_textgeneration/sample_0003_dragon_description/000_init.json
@@ -24,7 +24,7 @@
 		"instanceof": "knight",
 		"attributes": {
 			"color": "blonde",
-			"size": "meddium-sized"
+			"size": "medium-sized"
 		},
 		"pronouns": [
 			"She", "her"


### PR DESCRIPTION
## Summary
- correct a typo in the Dora_knight attributes inside `000_init.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d8882c188333814daa841f65981f